### PR TITLE
Add the position_imbeddings param to LlamaAttention.forward

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,9 +3,6 @@ permissions: read-all
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-    - main
 
 jobs:
   build:

--- a/intel_npu_acceleration_library/nn/llm.py
+++ b/intel_npu_acceleration_library/nn/llm.py
@@ -12,7 +12,7 @@ from transformers import AutoTokenizer
 from intel_npu_acceleration_library.nn import Linear
 from intel_npu_acceleration_library.backend import run_factory, MLP
 from functools import partial
-from typing import Optional, List, Generator
+from typing import Optional, List, Generator, Tuple
 from transformers.cache_utils import Cache
 import torch
 import uuid
@@ -169,6 +169,7 @@ class LlamaAttention(torch.nn.Module):
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,  # will become mandatory in Transformers v4.45
     ):
         """Torch module forward method.
 
@@ -180,6 +181,7 @@ class LlamaAttention(torch.nn.Module):
             output_attentions (Optional[bool], optional):  Whether or not to return the attentions tensors of all attention layers.. Defaults to False.
             use_cache (Optional[bool], optional): If set to `True`, `past_key_values` key value states are returned. Defaults to False.
             cache_position (Optional[torch.LongTensor], optional): Cache position useful for static cache applications . Defaults to None.
+            position_embeddings (Optional[Tuple[torch.Tensor, torch.Tensor]], optional): If set to a tuple, it means the `sin` and `cos` are uniformly calculated by the outer `LlamaModel` and passed in. Defaults to None.
 
         Returns:
             _type_: result
@@ -202,7 +204,10 @@ class LlamaAttention(torch.nn.Module):
             bsz, q_len, self.num_key_value_heads, self.head_dim
         ).transpose(1, 2)
 
-        cos, sin = self.rotary_emb(value_states, position_ids)
+        if position_embeddings is None:
+            cos, sin = self.rotary_emb(value_states, position_ids)
+        else:
+            cos, sin = position_embeddings
 
         query_states, key_states = apply_rotary_pos_emb(
             query_states, key_states, cos, sin, position_ids

--- a/intel_npu_acceleration_library/nn/llm.py
+++ b/intel_npu_acceleration_library/nn/llm.py
@@ -169,7 +169,9 @@ class LlamaAttention(torch.nn.Module):
         output_attentions: Optional[bool] = False,
         use_cache: Optional[bool] = False,
         cache_position: Optional[torch.LongTensor] = None,
-        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,  # will become mandatory in Transformers v4.45
+        position_embeddings: Optional[
+            Tuple[torch.Tensor, torch.Tensor]
+        ] = None,  # will become mandatory in Transformers v4.45
     ):
         """Torch module forward method.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 torch
-transformers>=4.39.3
+transformers>=4.43.0
 neural-compressor

--- a/test/python/test_compile.py
+++ b/test/python/test_compile.py
@@ -94,7 +94,7 @@ def test_torch_compile():
     ) or sys.version_info >= (3, 12):
         with pytest.raises(RuntimeError) as e:
             compiled_model = torch.compile(model, backend="npu")
-            assert str(e.value) == "Windows not yet supported for torch.compile"
+        assert str(e.value) == "Windows not yet supported for torch.compile"
     else:
         compiled_model = torch.compile(model, backend="npu")
         y = compiled_model(x).detach()

--- a/test/python/test_compile.py
+++ b/test/python/test_compile.py
@@ -89,9 +89,7 @@ def test_torch_compile():
     model = NN()
     y_ref = model(x.to(torch.float32)).detach()
 
-    if (
-        sys.platform == "win32" and Version(torch.__version__) < Version("2.2.2")
-    ) or sys.version_info >= (3, 12):
+    if sys.platform == "win32" and Version(torch.__version__) < Version("2.2.2"):
         with pytest.raises(RuntimeError) as e:
             compiled_model = torch.compile(model, backend="npu")
         assert str(e.value) == "Windows not yet supported for torch.compile"


### PR DESCRIPTION
The function `LlamaAttention.forward()` has a new param. 

https://github.com/huggingface/transformers/blob/2e113422b3504fe6de821bb9911b24273b11aa9c/src/transformers/models/llama/modeling_llama.py#L317

The param `position_embeddings` is calculated here. 

https://github.com/huggingface/transformers/blob/2e113422b3504fe6de821bb9911b24273b11aa9c/src/transformers/models/llama/modeling_llama.py#L917-L918

-----------

If the parameter is not added here, an error will occur when running the llama model: 

`TypeError: LlamaAttention.forward() got an unexpected keyword argument 'position_embeddings'`



